### PR TITLE
Make antimasker take points away

### DIFF
--- a/GameDesign/Assets/Scripts/States/Unmasking.cs
+++ b/GameDesign/Assets/Scripts/States/Unmasking.cs
@@ -31,6 +31,7 @@ public class Unmasking : State
     {
         if (movementManager.goToTargetToUnmask())
         {
+            PointsManager.Instance.TriggerEvent_IncrementPoints(-1 * _cmb.pointValue);
             //play animation to unmask.
             _cmb.doTriggerAnimation("Unmask");
         }


### PR DESCRIPTION
Now Antimaskers, take point away when they reach their objectives, so now it's not an advanage anymore.

Closes issue #83 