### PR TITLE
Remove points and decrease manager bar when taser someone with mask

### DIFF
--- a/GameDesign/Assets/Scripts/MonoBehaviours/CustomerMonoBehavior.cs
+++ b/GameDesign/Assets/Scripts/MonoBehaviours/CustomerMonoBehavior.cs
@@ -116,7 +116,6 @@ public class CustomerMonoBehavior : MonoBehaviour, Clickable
             clickCunt++;
             if (!wearsMask && clickCunt >= requiredClicks)
             {
-
                 onHitBehaviour();
             }
             else if (wearsMask)
@@ -135,6 +134,10 @@ public class CustomerMonoBehavior : MonoBehaviour, Clickable
         {
             if (taserManager.useTaser())
             {
+                if(wearsMask){
+                    PointsManager.Instance.TriggerEvent_IncrementPoints((int)(-0.75 * pointValue));
+                    ClickManager.Instance.onMissClickInvoke();
+                }
                 onFreezeBehaviour();
             }
         }


### PR DESCRIPTION
Added a check on CustomerMonoBehavior on Click to check if, when tased, the customer already has a mask. If he does, decrease points and the manager bar the same way the miss click does.

Closes #123 