### PR TITLE
added automatic TTL trigger when entering moving state

### DIFF
--- a/GameDesign/Assets/Scripts/MonoBehaviours/Movements/NPCMovementManager.cs
+++ b/GameDesign/Assets/Scripts/MonoBehaviours/Movements/NPCMovementManager.cs
@@ -20,6 +20,11 @@ public class NPCMovementManager : MonoBehaviour
     private float TTL = 0f;
     public int visibleWaypointsReached;
 
+
+    public void SetTTL(float newValue)
+    {
+        TTL = newValue;
+    }
     void Start()
     {
         initialRadius = distanceThreshHoldToReachTarget;

--- a/GameDesign/Assets/Scripts/States/Frozen.cs
+++ b/GameDesign/Assets/Scripts/States/Frozen.cs
@@ -23,7 +23,7 @@ public class Frozen : State
 
     public override void Tik()
     {
-        if(_cmb.currentSpeed!=0)
+        if (_cmb.currentSpeed != 0)
             _cmb.changeSpeed(0f);
     }
 
@@ -32,6 +32,9 @@ public class Frozen : State
         _cmb.defaultLayer = "Default";
         VFXManager.Instance.changeLayer(_cmb.gameObject, _cmb.defaultLayer);
         _cmb.changeSpeed();
+        NPCMovementManager movManager = _cmb.GetComponent<NPCMovementManager>();
+        if (movManager != null)
+            movManager.SetTTL(500f);
         _animator.SetBool("Tazered", false);
 
     }

--- a/GameDesign/Assets/Scripts/States/MovingState.cs
+++ b/GameDesign/Assets/Scripts/States/MovingState.cs
@@ -13,7 +13,6 @@ public class MovingState : State
     }
     public override void Enter()
     {
-        _moveManager.SetTTL(500f);
         _cmb.defaultLayer = "Default";
         VFXManager.Instance.changeLayer(_cmb.gameObject, _cmb.defaultLayer);
     }

--- a/GameDesign/Assets/Scripts/States/MovingState.cs
+++ b/GameDesign/Assets/Scripts/States/MovingState.cs
@@ -13,6 +13,7 @@ public class MovingState : State
     }
     public override void Enter()
     {
+        _moveManager.SetTTL(500f);
         _cmb.defaultLayer = "Default";
         VFXManager.Instance.changeLayer(_cmb.gameObject, _cmb.defaultLayer);
     }


### PR DESCRIPTION
wheneve an npc enters moving state TTL is set to a large number triggering its expiration, so a new waypoint is set for the characters target